### PR TITLE
Segregation and merge of custom rules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,11 +38,13 @@ When distributing
 
 You can add your own rules, when you publish the config file.
 
-    'commands' => array(
+    'custom' => array(
        'name/package' => 'CHANGELOG* phpunit.xml* tests docs',
     ),
 
-This wil look for files matching `CHANGELOG*` or `phpunit.xml*` or `tests` or `docs` in vendor/name/package and delete them.
+This will look for files matching `CHANGELOG*` or `phpunit.xml*` or `tests` or `docs` in vendor/name/package and delete them.
+
+When you publish the config file and add you own custom rules, it's recommended that you delete the "rules" setting in your published version so that you can benefit from any subsequent additions or changes made to the "officially" recognized rules.
 
 If the package is commonly used, please make a PR to add the command to src/Barryvdh/VendorCleanup/VendorCleanupCommand.php
 

--- a/src/Barryvdh/VendorCleanup/VendorCleanupCommand.php
+++ b/src/Barryvdh/VendorCleanup/VendorCleanupCommand.php
@@ -45,6 +45,8 @@ class VendorCleanupCommand extends Command
         $this->info("Cleaning dir: $vendorDir");
 
         $rules = \Config::get('laravel-vendor-cleanup::rules');
+        $custom = \Config::get('laravel-vendor-cleanup::custom', array());
+        $rules = array_merge($rules, $custom);
 
         $filesystem = new Filesystem();
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -18,11 +18,12 @@ return array(
     | Rules
     |--------------------------------------------------------------------------
     |
-    | Additional rules, to do your own cleanups
+    | Rules officially recognized by this package
     |
     */
 
     'rules' => array(
+        
         //Default Laravel 4 install
         'doctrine/annotations' => 'bin tests ',
         'doctrine/cache' => 'bin tests',
@@ -70,5 +71,21 @@ return array(
 
     ),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Custom rules
+    |--------------------------------------------------------------------------
+    |
+    | Additional rules, to do your own cleanups
+    | Use the same format as the rules above
+    |
+    | If your rules would be useful to others, why not
+    | do a PR instead to add them to the package?
+    |
+    */
+
+    'custom' => array(
+
+    ),
 
 );


### PR DESCRIPTION
Currently if the config is published to add custom rules, that blocks any new rules (or changes) subsequently added to the package.

This pull request separates the "official" rules from any "custom" rules, allowing custom rules to be created in and pulled from the published config while official rules can remain in the vendor folder and be updated from the repository.

Custom rules are merged with the official rules in such a way as to allow custom rules to overwrite the official version.
