### PR TITLE
Standard removal variable

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,90 +1,94 @@
-<?php return array(
+<?php
 
-	/*
-	|--------------------------------------------------------------------------
-	| Vendor dir
-	|--------------------------------------------------------------------------
-	|
-	| Default vendor dir
-	|
-	*/
-	'dir'   => base_path() . '/vendor',
-	
-	/*
-	|--------------------------------------------------------------------------
-	| Rules
-	|--------------------------------------------------------------------------
-	|
-	| Additional rules, to do your own cleanups
-	|
-	*/
-	'rules' => array(
-		// Default Laravel 4 install
-		'd11wtq/boris'                                               => 'README.md',
-		'filp/whoops'                                                => 'README.md phpunit.xml* tests examples',
-		'ircmaxell/password-compat'                                  => 'README.md test',
-		'laravel/framework'                                          => 'build tests',
-		'monolog/monolog'                                            => 'CHANGELOG.mdown README.mdown phpunit.xml* tests doc',
-		'nesbot/carbon'                                              => 'history.md readme.md phpunit.xml* tests',
-		'nikic/php-parser'                                           => 'README.md CHANGELOG* phpunit.xml* doc test test_old',
-		'patchwork/utf8'                                             => 'README.md tests',
-		'phpseclib/phpseclib'                                        => 'README* CHANGELOG* phpunit.xml* tests',
-		'predis/predis'                                              => 'README.md FAQ.md CONTRIBUTING.md CHANGELOG* phpunit.xml* examples tests bin',
-		'stack/builder'                                              => 'README* CHANGELOG* phpunit.xml* tests',
-		'swiftmailer/swiftmailer'                                    => 'CHANGES README* build* doc docs notes test-suite tests create_pear_package.php package*',
-		'symfony/browser-kit/Symfony/Component/BrowserKit'           => 'CHANGELOG* README* Tests',
-		'symfony/console/Symfony/Component/Console'                  => 'CHANGELOG* README* Tests',
-		'symfony/css-selector/Symfony/Component/CssSelector'         => 'CHANGELOG* README* Tests',
-		'symfony/debug/Symfony/Component/Debug'                      => 'CHANGELOG* README* Tests',
-		'symfony/dom-crawler/Symfony/Component/DomCrawler'           => 'CHANGELOG* README* Tests',
-		'symfony/event-dispatcher/Symfony/Component/EventDispatcher' => 'CHANGELOG* README* Tests',
-		'symfony/filesystem/Symfony/Component/Filesystem'            => 'CHANGELOG* README* Tests',
-		'symfony/finder/Symfony/Component/Finder'                    => 'CHANGELOG* README* Tests',
-		'symfony/http-foundation/Symfony/Component/HttpFoundation'   => 'CHANGELOG* README* Tests',
-		'symfony/http-kernel/Symfony/Component/HttpKernel'           => 'CHANGELOG* README* Tests',
-		'symfony/process/Symfony/Component/Process'                  => 'CHANGELOG* README* Tests',
-		'symfony/routing/Symfony/Component/Routing'                  => 'CHANGELOG* README* Tests',
-		'symfony/security/Symfony/Component/Security'                => 'CHANGELOG* README* Tests',
-		'symfony/translation/Symfony/Component/Translation'          => 'CHANGELOG* README* Tests',
-	
-		// Common packages
-		'anahkiasen/former'                                          => 'README* CHANGELOG* CONTRIBUTING* phpunit.xml* tests/*',
-		'anahkiasen/html-object'                                     => 'README* CHANGELOG* phpunit.xml* examples tests/*',
-		'anahkiasen/underscore-php'                                  => 'README* CHANGELOG* phpunit.xml* tests',
-		'barryvdh/laravel-debugbar'                                  => 'README* CHANGELOG* phpunit.xml* tests',
-		'bllim/datatables'                                           => 'README* CHANGELOG* phpunit.xml* tests',
-		'cartalyst/sentry'                                           => 'README* CHANGELOG* phpunit.xml* tests docs',
-		'dflydev/markdown'                                           => 'README* CHANGELOG* phpunit.xml* tests',
-		'doctrine/annotations'                                       => 'bin tests',
-		'doctrine/cache'                                             => 'bin tests',
-		'doctrine/collections'                                       => 'tests',
-		'doctrine/common'                                            => 'README* UPGRADE* phpunit.xml* build* tests bin lib/vendor',
-		'doctrine/dbal'                                              => 'bin build* docs docs2 tests lib/vendor',
-		'doctrine/inflector'                                         => 'phpunit.xml* README* tests',
-		'dompdf/dompdf'                                              => 'www',
-		'guzzle/guzzle'                                              => 'README* CHANGELOG* UPGRADING* phpunit.xml* docs tests',
-		'guzzlehttp/guzzle'					     => 'README* CHANGELOG* UPGRADING* phpunit.xml* docs tests',
-		'guzzlehttp/oauth-subscriber'				     => 'README* phpunit.xml* tests',
-		'guzzlehttp/streams'					     => 'README* phpunit.xml* tests',
-		'intervention/image'                                         => 'README* phpunit.xml* public tests',
-		'jasonlewis/basset'                                          => 'README* phpunit.xml* tests/Basset',
-		'jeremeamia/SuperClosure'                                    => 'README* CHANGELOG* phpunit.xml* tests demo',
-		'kriswallsmith/assetic'                                      => 'CHANGELOG* phpunit.xml* tests docs',
-		'leafo/lessphp'                                              => 'README* docs tests Makefile package.sh',
-		'maximebf/debugbar'                                          => 'README* CHANGELOG* CONTRIBUTING* phpunit.xml* docs tests demo',
-		'mockery/mockery'                                            => 'examples tests',
-		'mrclay/minify'                                              => 'HISTORY* MIN.txt UPGRADING* README* min_extras min_unit_tests min/builder min/config* min/quick-test* min/utils.php min/groupsConfig.php min/index.php',
-		'mustache/mustache'                                          => 'bin test',
-		'oyejorge/less.php'                                          => 'README* phpunit.xml* test',
-		'phenx/php-font-lib'                                         => 'www',
-		'phpdocumentor/reflection-docblock'                          => 'README* CHANGELOG* phpunit.xml* tests',
-		'phpoffice/phpexcel'                                         => 'Examples unitTests changelog.txt',
-		'rcrowe/twigbridge'                                          => 'README* CHANGELOG* phpunit.xml* tests',
-		'twig/twig'                                                  => 'README* CHANGELOG* phpunit.xml* test doc',
-		'venturecraft/revisionable'                                  => 'README* CHANGELOG* phpunit.xml* tests',
-		'willdurand/geocoder'                                        => 'README* CHANGELOG* CONTRIBUTING* phpunit.xml* tests',
+$standard = 'README* CHANGELOG* FAQ* CONTRIBUTING* HISTORY* UPGRADING* phpunit.xml* package* examples doc docs test tests';
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Vendor dir
+    |--------------------------------------------------------------------------
+    |
+    | Default vendor dir
+    |
+    */
+    'dir'   => base_path() . '/vendor',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rules
+    |--------------------------------------------------------------------------
+    |
+    | Additional rules, to do your own cleanups
+    |
+    */
+    'rules' => array(
+        // Default Laravel 4 install
+        'd11wtq/boris'                                               => "{$standard}",
+        'filp/whoops'                                                => "{$standard}",
+        'ircmaxell/password-compat'                                  => "{$standard}",
+        'laravel/framework'                                          => "{$standard} build",
+        'monolog/monolog'                                            => "{$standard}",
+        'nesbot/carbon'                                              => "{$standard}",
+        'nikic/php-parser'                                           => "{$standard} test_old",
+        'patchwork/utf8'                                             => "{$standard}",
+        'phpseclib/phpseclib'                                        => "{$standard}",
+        'predis/predis'                                              => "{$standard} bin",
+        'stack/builder'                                              => "{$standard}",
+        'swiftmailer/swiftmailer'                                    => "{$standard} build* notes test-suite create_pear_package.php",
+        'symfony/browser-kit/Symfony/Component/BrowserKit'           => "{$standard}",
+        'symfony/console/Symfony/Component/Console'                  => "{$standard}",
+        'symfony/css-selector/Symfony/Component/CssSelector'         => "{$standard}",
+        'symfony/debug/Symfony/Component/Debug'                      => "{$standard}",
+        'symfony/dom-crawler/Symfony/Component/DomCrawler'           => "{$standard}",
+        'symfony/event-dispatcher/Symfony/Component/EventDispatcher' => "{$standard}",
+        'symfony/filesystem/Symfony/Component/Filesystem'            => "{$standard}",
+        'symfony/finder/Symfony/Component/Finder'                    => "{$standard}",
+        'symfony/http-foundation/Symfony/Component/HttpFoundation'   => "{$standard}",
+        'symfony/http-kernel/Symfony/Component/HttpKernel'           => "{$standard}",
+        'symfony/process/Symfony/Component/Process'                  => "{$standard}",
+        'symfony/routing/Symfony/Component/Routing'                  => "{$standard}",
+        'symfony/security/Symfony/Component/Security'                => "{$standard}",
+        'symfony/translation/Symfony/Component/Translation'          => "{$standard}",
+
+        // Common packages
+        'anahkiasen/former'                     => "{$standard}",
+        'anahkiasen/html-object'                => "{$standard}",
+        'anahkiasen/underscore-php'             => "{$standard}",
+        'barryvdh/laravel-debugbar'             => "{$standard}",
+        'bllim/datatables'                      => "{$standard}",
+        'cartalyst/sentry'                      => "{$standard} docs",
+        'dflydev/markdown'                      => "{$standard}",
+        'doctrine/annotations'                  => "{$standard} bin",
+        'doctrine/cache'                        => "{$standard} bin",
+        'doctrine/collections'                  => "{$standard}",
+        'doctrine/common'                       => "{$standard} bin lib/vendor",
+        'doctrine/dbal'                         => "{$standard} bin build* docs2 lib/vendor",
+        'doctrine/inflector'                    => "{$standard}",
+        'dompdf/dompdf'                         => "{$standard} www",
+        'guzzle/guzzle'                         => "{$standard}",
+        'guzzlehttp/guzzle'                     => "{$standard}",
+        'guzzlehttp/oauth-subscriber'           => "{$standard}",
+        'guzzlehttp/streams'                    => "{$standard}",
+        'intervention/image'                    => "{$standard} public",
+        'jasonlewis/basset'                     => "{$standard}",
+        'jeremeamia/SuperClosure'               => "{$standard} demo",
+        'kriswallsmith/assetic'                 => "{$standard}",
+        'leafo/lessphp'                         => "{$standard} Makefile package.sh",
+        'maximebf/debugbar'                     => "{$standard} demo",
+        'mockery/mockery'                       => "{$standard}",
+        'mrclay/minify'                         => "{$standard} MIN.txt min_extras min_unit_tests min/builder min/config* min/quick-test* min/utils.php min/groupsConfig.php min/index.php",
+        'mustache/mustache'                     => "{$standard} bin",
+        'oyejorge/less.php'                     => "{$standard}",
+        'phenx/php-font-lib'                    => "{$standard} www",
+        'phpdocumentor/reflection-docblock'     => "{$standard}",
+        'phpoffice/phpexcel'                    => "{$standard} Examples unitTests changelog.txt",
+        'rcrowe/twigbridge'                     => "{$standard}",
+        'twig/twig'                             => "{$standard}",
+        'venturecraft/revisionable'             => "{$standard}",
+        'willdurand/geocoder'                   => "{$standard}",
 
         // Project specific packages
 
-	)
+    )
 );


### PR DESCRIPTION
Instead of writing README\* for every package, we could use a standard find/replace variable for all packages.
