### PR TITLE
Add Config facade so that \Config::get() works

### DIFF
--- a/src/Barryvdh/VendorCleanup/VendorCleanupCommand.php
+++ b/src/Barryvdh/VendorCleanup/VendorCleanupCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Config;
 
 class VendorCleanupCommand extends Command
 {


### PR DESCRIPTION
\Config::get() on line 89 was not working due to a namespace issue.