### PR TITLE
Remove \ from \Config::get() on line 89

### DIFF
--- a/src/Barryvdh/VendorCleanup/VendorCleanupCommand.php
+++ b/src/Barryvdh/VendorCleanup/VendorCleanupCommand.php
@@ -86,7 +86,7 @@ class VendorCleanupCommand extends Command
     protected function getArguments()
     {
         return array(
-            array('dir', InputArgument::OPTIONAL, 'The path to vendor (absolute path)', \Config::get('laravel-vendor-cleanup::dir', base_path() . '/vendor')),
+            array('dir', InputArgument::OPTIONAL, 'The path to vendor (absolute path)', Config::get('laravel-vendor-cleanup::dir', base_path() . '/vendor')),
         );
     }
 


### PR DESCRIPTION
Now that namespace is set in the file the \ on Config::get is no longer required.